### PR TITLE
Fixed INI parser issues

### DIFF
--- a/vcmp/lib/ini.c
+++ b/vcmp/lib/ini.c
@@ -221,6 +221,13 @@ void ini_free(ini_config *cfg)
     if (!cfg)
         return;
 
+    cur_keyval = cfg->global_keyvals;
+    while (cur_keyval != NULL) {
+        next_keyval = cur_keyval->next;
+        free(cur_keyval);
+        cur_keyval = next_keyval;
+    }
+
     cur_section = cfg->sections;
     if (cur_section == NULL) {
         goto final;
@@ -228,6 +235,8 @@ void ini_free(ini_config *cfg)
 
     while (cur_section != NULL) {
         next_section = cur_section->next;
+
+        cur_keyval = cur_section->keyvals;
         while (cur_keyval != NULL) {
             next_keyval = cur_keyval->next;
             free(cur_keyval->name);
@@ -241,7 +250,6 @@ void ini_free(ini_config *cfg)
 
         cur_section = next_section;
     }
-
 final:
     free(cfg);
 }
@@ -422,7 +430,7 @@ ini_config *ini_parsebuf(const char *buf)
                 tmp[i++] = *bufp++;
             }
 
-            while (*bufp != '=') {
+            while (*bufp++ != '=') {
                 if (*bufp == '\0' || *bufp == '\n') {
                     log_error("Invalid key-value pair.");
                     state = READY_FOR_DATA;

--- a/vcmp/lib/ini.h
+++ b/vcmp/lib/ini.h
@@ -27,7 +27,7 @@ char *ini_get_value(ini_config *cfg, const char *section, const char *key);
 ini_config *ini_parse(const char *filepath);
 ini_config *ini_parsebuf(const char *buf);
 
-#ifdef _DEBUG
+// #ifdef _DEBUG
 #include "log.h"
 #include <stddef.h>
 
@@ -64,8 +64,8 @@ static void ini_dump_config(ini_config *cfg)
         cur_section = cur_section->next;
     }
 }
-#else
-#define ini_dump_config(...)
-#endif // _DEBUG
+// #else
+// #define ini_dump_config(...)
+// #endif // _DEBUG
 
 #endif // _LIB_INI_H


### PR DESCRIPTION
Fixes double free in `ini_free()` and infinite loop when a whitespace is present in between a key and `=`